### PR TITLE
fix init value

### DIFF
--- a/demo/ChipmunkDemo.c
+++ b/demo/ChipmunkDemo.c
@@ -189,7 +189,7 @@ ChipmunkDemoDefaultDrawImpl(cpSpace *space)
 		ColorForShape,
 		{0.0f, 0.75f, 0.0f, 1.0f}, // Constraint color
 		{1.0f, 0.0f, 0.0f, 1.0f}, // Collision point color
-		NULL,
+		0,
 	};
 	
 	cpSpaceDebugDraw(space, &drawOptions);


### PR DESCRIPTION
Chipmunk2D/demo/ChipmunkDemo.c: In function ‘ChipmunkDemoDefaultDrawImpl’:
Chipmunk2D/demo/ChipmunkDemo.c:192:17: error: incompatible types when initializing type ‘double’ using type ‘void *’
  192 |                 NULL,
      |                 ^~~~